### PR TITLE
v0.6.4

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -1,5 +1,11 @@
 # Release History
 
+## v0.6.4
+- get_sex() function returns a dataframe that also includes percent of X and Y probes
+    that failed p-value-probe detection, as an indication of whether the predicted sex is reliable.
+- better unit test coverage of predictions, load, load_both, and container_to_pkl functions
+- fixed bug in load( 'meth_df')
+
 ## v0.6.3
 - fixed bug in detect_array() where it labeled EPIC+ as EPIC
 

--- a/methylcheck/load_processed.py
+++ b/methylcheck/load_processed.py
@@ -141,7 +141,7 @@ NOTES:
         meth_dfs = []
         unmeth_dfs = []
         for part in test_parts:
-            if 'meth_values' in part and 'noob' not in part:
+            if 'meth_values' in part and 'noob' not in part and 'unmeth_values' not in part:
                 meth_dfs.append( pd.read_pickle(part) )
             if 'unmeth_values' in part and 'noob' not in part:
                 unmeth_dfs.append( pd.read_pickle(part) )

--- a/methylcheck/predict/sex.py
+++ b/methylcheck/predict/sex.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sb
+from pathlib import Path
 #app
 import methylcheck # uses .load; get_sex uses methylprep models too and detect_array()
 
@@ -19,7 +20,7 @@ def _get_copy_number(meth,unmeth):
     return np.log2(meth+unmeth)
 
 
-def get_sex(data_source, array_type=None, verbose=False, plot=False, on_lambda=False):
+def get_sex(data_source, array_type=None, verbose=False, plot=False, on_lambda=False, median_cutoff= -2, include_probe_failure_percent=True):
     """This will calculate and predict the sex of each sample.
 
 inputs:
@@ -29,15 +30,25 @@ inputs:
         path -- to a folder with the 'meth_values.pkl' and 'unmeth_values.pkl' dataframes
         data_containers -- object created from methylprep.run_pipeline() or methylcheck.load(path, 'meth')
         tuple of (meth, unmeth) dataframes
+    array_type (string)
+        enum: {'27k','450k','epic','epic+','mouse'}
+        if not specified, it will load the data from data_source and determine the array for you.
+    median_cutoff
+        the minimum difference in the medians of X and Y probe copy numbers to assign male or female
+        (copied from the minif sex predict function)
 
 while providing a filepath is the easiest way, you can also pass in a data_containers object,
 a list of data_containers containing raw meth/unmeth values, instead. This object is produced
 by methylprep.run_pipeline, or by using methylcheck.load(filepath, format='meth') and lets you
 customize the import if your files were not prepared using methylprep (non-standand CSV columns, for example)
+
+If a `poobah_values.pkl` file can be found in path, the dataframe returned will also include
+percent of probes for X and Y chromosomes that failed quality control, and warn the user if any did.
+This feature won't work if a containers object is passed in, instead of a path.
+
+Note: ~90% of Y probes should fail if the sample is female. That chromosome is missing.
     """
-    ## TODO in unit testing for 100%:
-    ## test the ImportError
-    ## test all conditions on the array_type probe count logic.
+    allowed_array_types = {'27k','450k','epic','epic+','mouse'}
 
     try:
         from methylprep.files import Manifest
@@ -53,37 +64,20 @@ customize the import if your files were not prepared using methylprep (non-stand
         meth, unmeth = methylcheck.qc_plot._get_data(
             data_containers=None, path=data_source,
             compare=False, noob=False, verbose=False)
+        if include_probe_failure_percent == True and Path(data_source,'poobah_values.pkl').exists():
+            poobah = pd.read_pickle(Path(data_source,'poobah_values.pkl'))
+
     elif data_source_type in ('container'):
         # this will look for saved pickles first, then csvs or parsing the containers (which are both slower)
         # the saved pickles function isn't working for batches yet.
         meth, unmeth = methylcheck.qc_plot._get_data(
             data_containers=data_source, path=None,
             compare=False, noob=False, verbose=False)
+        poobah = None
+
     elif data_source_type is 'meth_unmeth_tuple':
         (meth, unmeth) = data_source
-
-    ''' # moved to _get_data in pc_plot.py
-    if filepath and not data_containers:
-        silent = False if verbose is True else False
-        data_containers = methylcheck.load(filepath, format='meth', silent=silent)
-
-    # Pull raw M and U values into one dataframe
-    if data_containers[0]._SampleDataContainer__data_frame.index.name != 'IlmnID':
-        data_containers[0]._SampleDataContainer__data_frame.rename_axis('IlmnID', inplace=True)
-
-    meth = pd.DataFrame(data_containers[0]._SampleDataContainer__data_frame.index)
-    unmeth = pd.DataFrame(data_containers[0]._SampleDataContainer__data_frame.index)
-    for i,c in enumerate(data_containers):
-        sample = data_containers[i].sample
-        if c._SampleDataContainer__data_frame.index.name != 'IlmnID':
-            c._SampleDataContainer__data_frame.rename_axis('IlmnID', inplace=True)
-        m = c._SampleDataContainer__data_frame.rename(columns={'meth':sample})
-        u = c._SampleDataContainer__data_frame.rename(columns={'unmeth':sample})
-        meth = pd.merge(left=meth, right=m[sample], left_on='IlmnID', right_on='IlmnID')
-        unmeth = pd.merge(left=unmeth, right=u[sample], left_on='IlmnID', right_on='IlmnID')
-    meth = meth.set_index('IlmnID')
-    unmeth = unmeth.set_index('IlmnID')
-    '''
+        poobah = None
 
     if len(meth) != len(unmeth):
         raise ValueError(f"WARNING: probe count mismatch: meth {len(meth)} -- unmeth {len(unmeth)}")
@@ -91,10 +85,15 @@ customize the import if your files were not prepared using methylprep (non-stand
     if array_type == None:
         # get list of X any Y probes - using .methylprep_manifest_files (or MANIFEST_DIR_PATH_LAMBDA) and auto-detected array here
         array_type = ArrayType(methylcheck.detect_array(meth, on_lambda=on_lambda))
+    elif isinstance(array_type,str):
+        if array_type in allowed_array_types:
+            array_type = ArrayType(array_type)
+        else:
+            raise ValueError(f"Your array_type must be one of these: {allowed_array_types} or None.")
 
     if verbose:
         LOGGER.debug(array_type)
-    LOGGER.setLevel(logging.DEBUG)
+    LOGGER.setLevel(logging.WARNING)
     manifest = Manifest(array_type, on_lambda=on_lambda)._Manifest__data_frame # 'custom', '27k', '450k', 'epic', 'epic+'
     LOGGER.setLevel(logging.INFO)
     x_probes = manifest.index[manifest['CHR']=='X']
@@ -120,17 +119,36 @@ customize the import if your files were not prepared using methylprep (non-stand
     output['y_median'] = output.index.map(y_med)
 
     # compute difference
-    difference = output['y_median'] - output['x_median']
+    median_difference = output['y_median'] - output['x_median']
 
-    # minfi cutoff - can be manipulated by user
-    cutoff = -2
-
-    # use cutoff to predict sex
-    sex0 = ['F' if x < -2 else 'M' for x in difference]
+    # median cutoff - can be manipulated by user --- default = -2 --- used to predict sex
+    sex0 = ['F' if x < median_cutoff else 'M' for x in median_difference]
 
     # populate dataframe with predicted sex
     output['predicted_sex'] = sex0
     output = output.round(1)
+
+    # if poobah_df exists, calculate percent X and Y probes that failed
+    if include_probe_failure_percent == True and isinstance(poobah, pd.DataFrame):
+        p_value_cutoff = 0.05
+        X_col = []
+        Y_col = []
+        failed_samples = []
+        for column in poobah.columns:
+            failed_probe_names = poobah[column][poobah[column] >= p_value_cutoff].index
+            failed_x_probe_names = list(set(failed_probe_names) & set(x_probes))
+            failed_y_probe_names = list(set(failed_probe_names) & set(y_probes))
+            X_percent = round(100*len(failed_x_probe_names)/poobah.index.isin(list(x_probes)).sum(),1)
+            Y_percent = round(100*len(failed_y_probe_names)/poobah.index.isin(list(y_probes)).sum(),1)
+            X_col.append(X_percent)
+            Y_col.append(Y_percent)
+            if X_percent > 10:
+                failed_samples.append(column)
+        output['X_fail_percent'] = X_col #output.index.map(X_col)
+        output['Y_fail_percent'] = Y_col #output.index.map(Y_col)
+        if failed_samples != []:
+            LOGGER.warning(f"{len(failed_samples)} samples had >10% of X probes fail p-value probe detection. Predictions for these may be unreliable:")
+            LOGGER.warning(f"{failed_samples}")
 
     if plot == True:
         sb.scatterplot(output['x_median'], output['y_median'], output['predicted_sex'])

--- a/methylcheck/version.py
+++ b/methylcheck/version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = '0.6.3'
+__version__ = '0.6.4'

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -6,8 +6,8 @@ def test_get_sex_from_path():
     output = methylcheck.get_sex(test_filepath, verbose=True, plot=False)
     print(output)
 
-def test_get_sex_from_path():
-    output = methylcheck.get_sex(test_filepath, array_type='EPIC', verbose=True, plot=False)
+def test_get_sex_from_path_array():
+    output = methylcheck.get_sex(test_filepath, array_type='epic', verbose=True, plot=False)
     print(output)
 
 def test_get_sex_from_data_containers():


### PR DESCRIPTION
## v0.6.4
- get_sex() function returns a dataframe that also includes percent of X and Y probes
    that failed p-value-probe detection, as an indication of whether the predicted sex is reliable.
- better unit test coverage of predictions, load, load_both, and container_to_pkl functions
- fixed bug in load( 'meth_df')